### PR TITLE
feat: トップページを追加し "/" → "/blog" リダイレクトを削除

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -27,7 +27,6 @@ export default defineConfig({
     }),
   },
   redirects: {
-    "/": "/blog",
     "/allow-3rd-party-plugin-to-amplify-override":
       "/blog/allow-3rd-party-plugin-to-amplify-override",
     "/anatomy-of-amplify-override": "/blog/anatomy-of-amplify-override",

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -7,7 +7,7 @@ import { SITE_TITLE } from "../consts";
   <nav>
     <h2><a href="/">{SITE_TITLE}</a></h2>
     <div class="internal-links">
-      <!-- <HeaderLink href="/">Home</HeaderLink> -->
+      <HeaderLink href="/">Home</HeaderLink>
       <HeaderLink href="/blog">Blog</HeaderLink>
       <!-- <HeaderLink href="/about">About</HeaderLink> -->
     </div>

--- a/src/consts.ts
+++ b/src/consts.ts
@@ -3,3 +3,7 @@
 
 export const SITE_TITLE = "fossamagna's Blog";
 export const SITE_DESCRIPTION = "Welcome to fossamagna's Blog!";
+
+export const HOME_TITLE = "Masahiko Murakami (fossamagna)";
+export const HOME_DESCRIPTION =
+  "Personal site of Masahiko Murakami (fossamagna), a software developer building web and cloud applications with AWS, TypeScript, and serverless technologies.";

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,0 +1,290 @@
+---
+import BaseHead from "../components/BaseHead.astro";
+import Header from "../components/Header.astro";
+import Footer from "../components/Footer.astro";
+import { HOME_TITLE, HOME_DESCRIPTION } from "../consts";
+
+const skills = [
+  "AWS",
+  "Serverless",
+  "AWS Amplify",
+  "AppSync / GraphQL",
+  "TypeScript",
+  "Node.js",
+  "React",
+  "Flutter",
+  "VS Code Extensions",
+];
+---
+
+<!doctype html>
+<html lang="en">
+  <head>
+    <BaseHead
+      title={HOME_TITLE}
+      description={HOME_DESCRIPTION}
+      image="/blog-placeholder-about.jpg"
+    />
+    <style>
+      .hero {
+        padding: 2rem 0 2rem 0;
+      }
+      .hero .eyebrow {
+        margin: 0 0 0.5rem 0;
+        color: rgb(var(--gray));
+        text-transform: uppercase;
+        letter-spacing: 0.08em;
+        font-size: 0.9rem;
+      }
+      .hero h1 {
+        margin: 0 0 0.25rem 0;
+      }
+      .hero .tagline {
+        margin: 0 0 1.5rem 0;
+        color: rgb(var(--gray-dark));
+        font-size: 1.563rem;
+        line-height: 1.3;
+      }
+      .hero .intro {
+        max-width: 60ch;
+      }
+      .actions {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 0.75rem;
+        margin-top: 1.5rem;
+      }
+      .button {
+        display: inline-block;
+        padding: 0.6em 1.2em;
+        border-radius: 8px;
+        text-decoration: none;
+        font-weight: 700;
+        transition: 0.2s ease;
+      }
+      .button.primary {
+        background: var(--accent);
+        color: white;
+      }
+      .button.primary:hover {
+        background: var(--accent-dark);
+      }
+      .button.secondary {
+        border: 1px solid rgb(var(--gray-light));
+        color: rgb(var(--gray-dark));
+      }
+      .button.secondary:hover {
+        border-color: var(--accent);
+        color: var(--accent);
+      }
+      section.block {
+        padding: 3rem 0;
+        border-top: 1px solid rgb(var(--gray-light));
+      }
+      section.block h2 {
+        font-size: 1.953rem;
+        margin-bottom: 1.25rem;
+      }
+      .tags {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 0.6rem;
+        list-style: none;
+        margin: 0;
+        padding: 0;
+      }
+      .tags li {
+        padding: 0.35em 0.9em;
+        background: rgb(var(--gray-light));
+        border-radius: 999px;
+        font-size: 0.95rem;
+        color: rgb(var(--gray-dark));
+      }
+      .community {
+        list-style: none;
+        margin: 0;
+        padding: 0;
+        display: flex;
+        flex-direction: column;
+        gap: 1rem;
+      }
+      .community li {
+        display: flex;
+        flex-wrap: wrap;
+        align-items: baseline;
+        gap: 0.25rem 0.75rem;
+      }
+      .community a.name {
+        font-weight: 700;
+        color: rgb(var(--black));
+        text-decoration: none;
+        transition: 0.2s ease;
+      }
+      .community a.name:hover {
+        color: var(--accent);
+        text-decoration: underline;
+      }
+      .community .role {
+        color: rgb(var(--gray));
+        font-size: 0.95rem;
+      }
+      .links {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 1rem;
+        list-style: none;
+        margin: 0;
+        padding: 0;
+      }
+      .links a {
+        display: inline-flex;
+        align-items: center;
+        gap: 0.5rem;
+        text-decoration: none;
+        color: rgb(var(--gray-dark));
+        transition: 0.2s ease;
+      }
+      .links a:hover {
+        color: var(--accent);
+      }
+      .links svg {
+        flex: none;
+      }
+    </style>
+  </head>
+  <body>
+    <!-- Google Tag Manager (noscript) -->
+    <noscript
+      ><iframe
+        src="https://www.googletagmanager.com/ns.html?id=GTM-PDR994WX"
+        height="0"
+        width="0"
+        style="display:none;visibility:hidden"></iframe></noscript
+    >
+    <!-- End Google Tag Manager (noscript) -->
+    <Header />
+    <main>
+      <section class="hero">
+        <p class="eyebrow">Software Developer</p>
+        <h1>Masahiko Murakami</h1>
+        <p class="tagline">
+          Building web and cloud applications, also known as <strong
+            >fossamagna</strong
+          >.
+        </p>
+        <div class="intro">
+          <p>
+            I'm a software developer who enjoys building things on the web and
+            in the cloud. My main focus is AWS and serverless architectures,
+            with TypeScript across the full stack. I like digging into AWS
+            Amplify, AppSync, and developer tooling, and I write about what I
+            learn on my blog.
+          </p>
+        </div>
+        <div class="actions">
+          <a class="button primary" href="/blog">Read the blog</a>
+          <a class="button secondary" href="https://github.com/fossamagna"
+            >GitHub</a
+          >
+        </div>
+      </section>
+
+      <section class="block">
+        <h2>What I work with</h2>
+        <ul class="tags">
+          {skills.map((skill) => <li>{skill}</li>)}
+        </ul>
+      </section>
+
+      <section class="block">
+        <h2>Community</h2>
+        <ul class="community">
+          <li>
+            <a
+              class="name"
+              href="https://builder.aws.com/community/@fossamagna"
+              target="_blank"
+              rel="noopener">AWS Community Builder (DevTools)</a
+            >
+            <span class="role">since 2022</span>
+          </li>
+          <li>
+            <a
+              class="name"
+              href="https://aws-amplify-jp.github.io/"
+              target="_blank"
+              rel="noopener">Amplify Japan User Group</a
+            >
+            <span class="role">Organizer</span>
+          </li>
+          <li>
+            <a
+              class="name"
+              href="https://jawsug-fukui.connpass.com/"
+              target="_blank"
+              rel="noopener">JAWS-UG Fukui</a
+            >
+            <span class="role">Organizer</span>
+          </li>
+        </ul>
+      </section>
+
+      <section class="block">
+        <h2>Find me online</h2>
+        <ul class="links">
+          <li>
+            <a href="https://github.com/fossamagna" target="_blank" rel="me">
+              <svg viewBox="0 0 16 16" aria-hidden="true" width="24" height="24"
+                ><path
+                  fill="currentColor"
+                  d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.012 8.012 0 0 0 16 8c0-4.42-3.58-8-8-8z"
+                ></path></svg
+              >
+              <span>github.com/fossamagna</span>
+            </a>
+          </li>
+          <li>
+            <a href="https://x.com/fossamagna" target="_blank" rel="me">
+              <svg width="24" height="24" viewBox="0 0 32 32" aria-hidden="true">
+                <path
+                  transform="scale(0.105)"
+                  fill="currentColor"
+                  d="M178.57 127.15 290.27 0h-26.46l-97.03 110.38L89.34 0H0l117.13 166.93L0 300.25h26.46l102.4-116.59 81.8
+    116.59h89.34M36.01 19.54H76.66l187.13 262.13h-40.66"
+                ></path>
+              </svg>
+              <span>@fossamagna</span>
+            </a>
+          </li>
+          <li>
+            <a
+              href="https://www.linkedin.com/in/masahiko-murakami-23563b24a/"
+              target="_blank"
+              rel="me"
+            >
+              <svg width="24" height="24" viewBox="0 0 24 24" aria-hidden="true"
+                ><path
+                  fill="currentColor"
+                  d="M19 0h-14c-2.761 0-5 2.239-5 5v14c0 2.761 2.239 5 5 5h14c2.762 0 5-2.239 5-5v-14c0-2.761-2.238-5-5-5zm-11 19h-3v-11h3v11zm-1.5-12.268c-.966 0-1.75-.79-1.75-1.764s.784-1.764 1.75-1.764 1.75.79 1.75 1.764-.783 1.764-1.75 1.764zm13.5 12.268h-3v-5.604c0-3.368-4-3.113-4 0v5.604h-3v-11h3v1.765c1.396-2.586 7-2.777 7 2.476v6.759z"
+                ></path></svg
+              >
+              <span>LinkedIn</span>
+            </a>
+          </li>
+          <li>
+            <a href="/rss.xml">
+              <svg width="24" height="24" viewBox="0 0 24 24" aria-hidden="true"
+                ><path
+                  fill="currentColor"
+                  d="M6.18 15.64a2.18 2.18 0 0 1 2.18 2.18C8.36 19 7.38 20 6.18 20A2.18 2.18 0 0 1 4 17.82a2.18 2.18 0 0 1 2.18-2.18M4 4.44A15.56 15.56 0 0 1 19.56 20h-2.83A12.73 12.73 0 0 0 4 7.27V4.44m0 5.66a9.9 9.9 0 0 1 9.9 9.9h-2.83A7.07 7.07 0 0 0 4 12.93V10.1z"
+                ></path></svg
+              >
+              <span>RSS feed</span>
+            </a>
+          </li>
+        </ul>
+      </section>
+    </main>
+    <Footer />
+  </body>
+</html>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -29,6 +29,15 @@ const skills = [
       .hero {
         padding: 2rem 0 2rem 0;
       }
+      .hero .avatar {
+        width: 120px;
+        height: 120px;
+        border-radius: 50%;
+        object-fit: cover;
+        margin-bottom: 1.25rem;
+        border: 3px solid white;
+        box-shadow: var(--box-shadow);
+      }
       .hero .eyebrow {
         margin: 0 0 0.5rem 0;
         color: rgb(var(--gray));
@@ -165,6 +174,15 @@ const skills = [
     <Header />
     <main>
       <section class="hero">
+        <img
+          class="avatar"
+          src="https://github.com/fossamagna.png"
+          width="120"
+          height="120"
+          alt="Masahiko Murakami"
+          loading="eager"
+          decoding="async"
+        />
         <p class="eyebrow">Software Developer</p>
         <h1>Masahiko Murakami</h1>
         <p class="tagline">


### PR DESCRIPTION
## 概要

サイトのトップ (`/`) に開発者向けの個人トップページを追加し、これまでの `/` → `/blog` リダイレクトを削除しました。トップにアクセスすると、ブログではなく自己紹介ページが表示されます。

## 変更内容

- **トップページ追加** ([src/pages/index.astro](src/pages/index.astro)) — 英語表記、既存テーマ（Bear Blog ベース）に合わせたスタイル。以下のセクションで構成:
  - **Hero** — 肩書き・名前・ハンドル・紹介文と、ブログ/GitHub への CTA
  - **What I work with** — 技術スタックをタグ表示（AWS, Serverless, AWS Amplify, AppSync/GraphQL, TypeScript, Node.js, React, Flutter, VS Code Extensions）
  - **Community** — AWS Community Builder (DevTools, since 2022) / Amplify Japan User Group (Organizer) / JAWS-UG Fukui (Organizer)、各項目に外部リンク
  - **Find me online** — GitHub, X, LinkedIn, RSS feed へのリンク
- **`/` → `/blog` リダイレクトを削除** ([astro.config.mjs](astro.config.mjs)) — 個別記事のリダイレクトは維持
- **Home ナビリンクを有効化** ([Header.astro](src/components/Header.astro))
- **トップページ用の `HOME_TITLE` / `HOME_DESCRIPTION` を追加** ([consts.ts](src/consts.ts))

## 確認

- `npm run build` 成功、ローカル dev サーバーでトップページ表示・各リンクを確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)