### PR TITLE
feat: トップページの OGP / X カード画像を追加

### DIFF
--- a/src/components/OgpImage.tsx
+++ b/src/components/OgpImage.tsx
@@ -33,6 +33,106 @@ const getGoogleFontData = async (query: string): Promise<ArrayBuffer> => {
   return arrayBuffer;
 };
 
+export const getHomeOgpImageResponse = async (): Promise<Response> => {
+  return new ImageResponse(
+    (
+      <div
+        lang="en-US"
+        style={{
+          display: "flex",
+          flexDirection: "column",
+          width: "100%",
+          height: "100%",
+          background: "linear-gradient(to bottom, rgb(229, 233, 240), white)",
+          padding: "80px",
+          fontFamily: "Noto Sans JP",
+        }}
+      >
+        <div
+          style={{
+            display: "flex",
+            flexDirection: "column",
+            flex: 1,
+            justifyContent: "center",
+          }}
+        >
+          <div
+            style={{
+              fontSize: "32px",
+              fontWeight: 700,
+              letterSpacing: "4px",
+              color: "rgb(96, 115, 159)",
+              marginBottom: "24px",
+            }}
+          >
+            SOFTWARE DEVELOPER
+          </div>
+          <div
+            style={{
+              fontSize: "84px",
+              fontWeight: 700,
+              color: "rgb(15, 18, 25)",
+              lineHeight: 1.1,
+              marginBottom: "24px",
+            }}
+          >
+            Masahiko Murakami
+          </div>
+          <div
+            style={{
+              fontSize: "40px",
+              fontWeight: 700,
+              color: "rgb(34, 41, 57)",
+            }}
+          >
+            Building web and cloud applications
+          </div>
+        </div>
+        <div
+          style={{
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "space-between",
+            borderTop: "1px solid rgb(229, 233, 240)",
+            paddingTop: "32px",
+          }}
+        >
+          <div
+            style={{
+              fontSize: "36px",
+              fontWeight: 700,
+              color: "rgb(15, 18, 25)",
+            }}
+          >
+            @fossamagna
+          </div>
+          <div
+            style={{
+              fontSize: "32px",
+              fontWeight: 700,
+              color: "rgb(96, 115, 159)",
+            }}
+          >
+            fossamagna.github.io
+          </div>
+        </div>
+      </div>
+    ),
+    {
+      width: 1200,
+      height: 630,
+      fonts: [
+        {
+          name: "Noto Sans JP",
+          data: await getGoogleFontData("Noto+Sans+JP:wght@700"),
+          style: "normal",
+          weight: 700,
+        },
+      ],
+    }
+  );
+};
+
 export const getBlogPostOgpImageResponse = async (params: {
   title: string;
 }): Promise<Response> => {

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -23,7 +23,7 @@ const skills = [
     <BaseHead
       title={HOME_TITLE}
       description={HOME_DESCRIPTION}
-      image="/blog-placeholder-about.jpg"
+      image="/ogp.png"
     />
     <style>
       .hero {

--- a/src/pages/ogp.png.ts
+++ b/src/pages/ogp.png.ts
@@ -1,0 +1,6 @@
+import type { APIRoute } from "astro";
+import { getHomeOgpImageResponse } from "../components/OgpImage";
+
+export const GET: APIRoute = async () => {
+  return getHomeOgpImageResponse();
+};


### PR DESCRIPTION
## 概要

トップページ (`/`) 用の OGP / X (Twitter) カード画像を追加しました。これまでプレースホルダ画像を指定していた箇所を、専用の動的生成画像に差し替えます。

## 変更内容

- **トップページ用 OGP 画像生成関数を追加** ([src/components/OgpImage.tsx](src/components/OgpImage.tsx)) — `getHomeOgpImageResponse()`。ブログ記事 OGP と同じ仕組み（@vercel/og）・トーンで 1200×630 のカードを生成。既存のフォント取得ロジックを再利用
- **`/ogp.png` ルートを追加** ([src/pages/ogp.png.ts](src/pages/ogp.png.ts))
- **トップページの OGP 画像を `/ogp.png` に変更** ([src/pages/index.astro](src/pages/index.astro)) — `og:image` / `twitter:image` の両方に反映（`twitter:card` は既存の `summary_large_image`）

## 画像の内容（1200×630）

- SOFTWARE DEVELOPER（ラベル）
- Masahiko Murakami（見出し）
- Building web and cloud applications（タグライン）
- フッター: @fossamagna / fossamagna.github.io

## 確認

- `npm run build` 成功。`dist/ogp.png`（PNG 1200×630）が生成され、`dist/index.html` の `og:image` が `https://fossamagna.github.io/ogp.png` を指すことを確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)